### PR TITLE
Add Discord community link to homepage

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -85,6 +85,30 @@ export default function HomePage() {
         <div className="mt-3 p-4 bg-yellow-900/40 border-l-4 border-yellow-500 rounded-r-lg text-sm text-yellow-300">
           此邀請連結每個帳號最多只能使用五次，如果顯示無效，也歡迎加入本站的 Discord 群，在「邀請碼分享」頻道尋找可用的推薦連結。
         </div>
+
+        {/* Discord 社群連結 */}
+        <div className="mt-3 flex items-center gap-3 p-4 bg-blue-900/30 border border-blue-700 rounded-lg">
+          <svg
+            className="w-6 h-6 flex-shrink-0 text-blue-400"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418z"/>
+          </svg>
+          <div>
+            <span className="text-blue-300">加入 GeoPingKak Discord 社群：</span>
+            <a
+              href="https://discord.gg/ABpdGBbDe4"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-2 text-blue-400 underline hover:text-blue-300 transition-colors"
+            >
+              discord.gg/ABpdGBbDe4
+            </a>
+          </div>
+        </div>
+
         <p className="mt-6 p-4 bg-red-900/50 border-l-4 border-red-500 rounded-r-lg font-bold text-red-400">
           注意：GeoGuessr 在 Steam 有上架，但 Steam 版是相同價格的閹割版，目前只做完對戰模式，沒有其他東西能玩。目前不建議購買 Steam 版。
         </p>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -87,27 +87,27 @@ export default function HomePage() {
         </div>
 
         {/* Discord 社群連結 */}
-        <div className="mt-3 flex items-center gap-3 p-4 bg-blue-900/30 border border-blue-700 rounded-lg">
+        <a
+          href="https://discord.gg/ABpdGBbDe4"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 flex items-center gap-3 p-4 bg-blue-900/30 border border-blue-700 rounded-lg hover:bg-blue-900/50 hover:border-blue-600 transition-colors group"
+        >
           <svg
-            className="w-6 h-6 flex-shrink-0 text-blue-400"
+            className="w-6 h-6 flex-shrink-0 text-blue-400 group-hover:text-blue-300 transition-colors"
             viewBox="0 0 24 24"
             fill="currentColor"
             aria-hidden="true"
           >
             <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0a12.64 12.64 0 0 0-.617-1.25a.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.078.078 0 0 0 .084-.028a14.09 14.09 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13.107 13.107 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10.2 10.2 0 0 0 .372-.292a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127a12.299 12.299 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028a19.839 19.839 0 0 0 6.002-3.03a.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418z"/>
           </svg>
-          <div>
-            <span className="text-blue-300">加入 GeoPingKak Discord 社群：</span>
-            <a
-              href="https://discord.gg/ABpdGBbDe4"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ml-2 text-blue-400 underline hover:text-blue-300 transition-colors"
-            >
-              discord.gg/ABpdGBbDe4
-            </a>
+          <div className="flex items-center gap-2">
+            <span className="text-blue-300 group-hover:text-blue-200 transition-colors">加入 GeoPingKak Discord 社群</span>
+            <svg className="w-4 h-4 text-blue-400 group-hover:text-blue-300 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
           </div>
-        </div>
+        </a>
 
         <p className="mt-6 p-4 bg-red-900/50 border-l-4 border-red-500 rounded-r-lg font-bold text-red-400">
           注意：GeoGuessr 在 Steam 有上架，但 Steam 版是相同價格的閹割版，目前只做完對戰模式，沒有其他東西能玩。目前不建議購買 Steam 版。


### PR DESCRIPTION
## Summary
Added a Discord community link section to the homepage to encourage users to join the GeoPingKak Discord server for support and invitation code sharing.

## Changes
- Added a new informational card with Discord branding below the invitation link warning message
- Included Discord logo SVG icon for visual recognition
- Provided direct link to the Discord server (discord.gg/ABpdGBbDe4)
- Styled with blue color scheme to match Discord branding and maintain consistency with the page's design language
- Added hover effects and proper accessibility attributes (aria-hidden, target="_blank", rel="noopener noreferrer")

## Implementation Details
- Used existing design patterns from the page (colored background cards with borders)
- Discord SVG icon is properly sized and colored to match the blue theme
- Link opens in a new tab with security best practices
- Text is in Traditional Chinese to match the existing content language

https://claude.ai/code/session_01Vyy5daP8dCDiTN7cMXiTUT